### PR TITLE
pull clover down using curl

### DIFF
--- a/experimental-install-Clover.sh
+++ b/experimental-install-Clover.sh
@@ -2,6 +2,7 @@
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
+CLOVER_VERSION='5151'
 
 clear
 
@@ -42,8 +43,13 @@ else
 	exit
 fi
 
+# obtain Clover ISO
+clover_archive=$(curl -s -O -L -w "%{filename_effective}" "https://github.com/CloverHackyColor/CloverBootloader/releases/download/${CLOVER_VERSION}/Clover-${CLOVER_VERSION}-X64.iso.7z")
+clover_base=$(basename -s .7z $clover_archive)
+7z x $clover_archive -aoa $clover_base
+
 # mount Clover ISO
-sudo mkdir ~/temp-clover && sudo mount Clover-5151-X64.iso ~/temp-clover &> /dev/null
+sudo mkdir ~/temp-clover && sudo mount $clover_base ~/temp-clover &> /dev/null
 if [ $? -eq 0 ]
 then
 	echo -e "$GREEN"2nd sanity check. ISO has been mounted!
@@ -61,7 +67,7 @@ if [ $? -eq 0 ]
 then
 	echo -e "$GREEN"3rd sanity check. Clover has been copied to the EFI system partition!
 else
-	echo -e $"RED"Error copying files. Something went wrong.
+	echo -e "$RED"Error copying files. Something went wrong.
 	sudo umount ~/temp-clover
 	rmdir ~/temp-clover
 	exit


### PR DESCRIPTION
I have yet to test this, but I wanted to get this put in there to save you some time.

The zip file _appears_ to be exactly the same as the iso, and can be unzipped with `unzip` which should be available on base SteamOS installs on the Deck.