### PR TITLE
Fixed a bug about 'Timeout'moudle's description

### DIFF
--- a/custom/Clover-Toolbox.sh
+++ b/custom/Clover-Toolbox.sh
@@ -84,7 +84,7 @@ Timeout_Choice=$(zenity --width 500 --height 300 --list --radiolist --multiple 	
 	FALSE 5 "Set the default timeout to 5secs."\
 	FALSE 10 "Set the default timeout to 10secs."\
 	FALSE 15 "Set the default timeout to 15secs."\
- 	FALSE 60 "Set the default timeout to 15secs."\
+ 	FALSE 60 "Set the default timeout to 60secs."\
 	TRUE EXIT "***** Exit the Clover Toolbox *****")
 
 	if [ $? -eq 1 ] || [ "$Timeout_Choice" == "EXIT" ]


### PR DESCRIPTION
Fixed a bug
Set timeout to 60 seconds before entering the default system, but the description in the toolbox is still 15 seconds