### PR TITLE
Update Clover to 5161

### DIFF
--- a/install-clover.sh
+++ b/install-clover.sh
@@ -63,7 +63,7 @@ fi
 CLOVER=$(efibootmgr | grep -i Clover | colrm 9 | colrm 1 4)
 REFIND=$(efibootmgr | grep -i rEFInd | colrm 9 | colrm 1 4)
 ESP=$(df /dev/nvme0n1p1 --output=avail | tail -n1)
-CLOVER_VERSION=5160
+CLOVER_VERSION=5161
 CLOVER_URL=https://github.com/CloverHackyColor/CloverBootloader/releases/download/$CLOVER_VERSION/Clover-$CLOVER_VERSION-X64.iso.7z
 CLOVER_ARCHIVE=$(curl -s -O -L -w "%{filename_effective}" $CLOVER_URL)
 CLOVER_BASE=$(basename -s .7z $CLOVER_ARCHIVE)


### PR DESCRIPTION
Update Clover to 5161.

This alone will not fix any issue and should not change anything user-facing. It is merely to make it easy to demonstrate that known issues are still present on the latest version of Clover, should I report them to the upstream.